### PR TITLE
Release v0.8.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ Brewhouse Manager now supports **two integration methods** for Plaato Keg device
 
 #### Other Tap Monitoring Sensors
 
-- [Kegtron Pro](https://kegtron.com/pro/)
+- Kegtron
+  - [Kegtron Pro](https://kegtron.com/pro/)
+  - [Kegtron Gen1](https://kegtron.com/gen1/) (via [Kegtron Gen1 API Proxy](https://github.com/alanquillin/kegtron-gen1-api-proxy))
 - [DIY Keg Volume Monitors](https://github.com/alanquillin/keg-volume-monitors)
 
 ## Quick Installation

--- a/api/api.py
+++ b/api/api.py
@@ -27,7 +27,7 @@ if not _secret_key:
 # Create FastAPI app
 api = FastAPI(
     title="Brewhouse Manager",
-    version="0.8.0",
+    version="0.8.1",
     docs_url="/api/docs",
     redoc_url="/api/redoc" if CONFIG.get("ENV") == "development" else None,
 )

--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -101,11 +101,13 @@ async def google_login(request: Request):
     )
 
     flow.redirect_uri = redirect_url
+    flow.autogenerate_code_verifier = True
 
     authorization_url, state = flow.authorization_url(access_type="offline", include_granted_scopes="true")
 
-    # Store state in session to verify callback
+    # Store state and code_verifier in session for the callback
     request.session["oauth_state"] = state
+    request.session["oauth_code_verifier"] = flow.code_verifier
 
     LOGGER.debug("Redirecting to Google SSO: %s", authorization_url)
     return RedirectResponse(url=authorization_url)
@@ -146,6 +148,11 @@ async def google_callback(request: Request, code: str, state: str, db_session: A
     )
 
     flow.redirect_uri = redirect_url
+
+    # Restore PKCE code_verifier from session
+    code_verifier = request.session.get("oauth_code_verifier")
+    if code_verifier:
+        flow.code_verifier = code_verifier
 
     # Exchange authorization code for tokens (blocking I/O — run in thread)
     await asyncio.to_thread(flow.fetch_token, code=code)
@@ -226,6 +233,7 @@ async def google_callback(request: Request, code: str, state: str, db_session: A
 
     # Clear oauth state from session
     request.session.pop("oauth_state", None)
+    request.session.pop("oauth_code_verifier", None)
 
     # Set session cookie
     request.session["user_id"] = str(user.id)

--- a/api/tests/unit/test_api.py
+++ b/api/tests/unit/test_api.py
@@ -243,7 +243,7 @@ class TestFastAPIAppConfiguration:
     def test_api_has_version(self, api_module):
         """Test API has version set"""
         assert api_module.api.version is not None
-        assert api_module.api.version == "0.8.0"
+        assert api_module.api.version == "0.8.1"
 
     def test_api_has_docs_url(self, api_module):
         """Test API has docs URL configured"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ markers = [
 
 [tool.poetry]
 name = "brewhouse-manager"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["alanquillin"]
 description = "Brewhouse Manager"
 

--- a/scripts/update-version.sh
+++ b/scripts/update-version.sh
@@ -65,6 +65,15 @@ else
     echo -e "  ${RED}✗${NC} File not found: $PACKAGE_JSON"
 fi
 
+# Update api/tests/unit/test_api.py
+TEST_API="$PROJECT_ROOT/api/tests/unit/test_api.py"
+if [ -f "$TEST_API" ]; then
+    sed -i '' "s/api_module.api.version == \".*\"/api_module.api.version == \"$VERSION\"/" "$TEST_API"
+    echo -e "  ${GREEN}✓${NC} Updated $TEST_API"
+else
+    echo -e "  ${RED}✗${NC} File not found: $TEST_API"
+fi
+
 # Update ui/src/environments/environment.prod.ts
 ENV_PROD="$PROJECT_ROOT/ui/src/environments/environment.prod.ts"
 if [ -f "$ENV_PROD" ]; then

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brewhouse-manager",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  appVersion: '0.8.0',
+  appVersion: '0.8.1',
 };


### PR DESCRIPTION
## Summary
- Fix Google OAuth login by adding PKCE (code verifier) support — Google now enforces this
- Update version to 0.8.1 across all project files
- Fix `update-version.sh` script to also update the version assertion in `api/tests/unit/test_api.py`
- Update README

## Test plan
- [x] Google OAuth login works locally with PKCE flow
- [x] `make update-version VERSION=x.y.z` updates all files including the unit test
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the Google OAuth login flow and session state, which is security-sensitive and could break authentication if misconfigured. Other changes are version/documentation updates with low functional risk.
> 
> **Overview**
> **Fixes Google SSO login by adding PKCE support**: enables `autogenerate_code_verifier`, stores the PKCE `code_verifier` in the session during `/login/google`, restores it in the callback before `fetch_token`, and clears it after login.
> 
> Bumps release version to `0.8.1` across backend, UI, and tests (`api/api.py`, `pyproject.toml`, `ui/package.json`, `environment.prod.ts`, `test_api.py`), and updates `update-version.sh` to also rewrite the unit-test version assertion. Updates README tap-monitoring sensor docs (Kegtron section).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0330a55285009fe4805df0624a63f910c4774ee1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->