### PR TITLE
V0.8.3

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -27,7 +27,7 @@ if not _secret_key:
 # Create FastAPI app
 api = FastAPI(
     title="Brewhouse Manager",
-    version="0.8.2",
+    version="0.8.3",
     docs_url="/api/docs",
     redoc_url="/api/redoc" if CONFIG.get("ENV") == "development" else None,
 )

--- a/api/routers/beers.py
+++ b/api/routers/beers.py
@@ -15,6 +15,7 @@ from dependencies.auth import AuthUser, get_db_session, require_user
 from lib import logging
 from schemas.beers import BeerCreate, BeerUpdate
 from services.beers import BeerService
+from services.taps import TapService
 
 router = APIRouter(prefix="/api/v1/beers", tags=["beers"])
 LOGGER = logging.getLogger(__name__)
@@ -141,6 +142,7 @@ async def delete_beer(
         )
 
     for batch in batches:
+        await TapService.clear_on_tap_references_for_batch(db_session, batch.id, autocommit=False)
         await BatchLocationsDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
         await OnTapDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
         await BatchOverridesDB.delete_by(db_session, batch_id=batch.id, autocommit=False)

--- a/api/routers/beers.py
+++ b/api/routers/beers.py
@@ -5,9 +5,13 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# isort: off
+# fmt: off
+from db.batches import Batches as BatchesDB  # pylint: disable=wrong-import-position
 from db.batch_locations import BatchLocations as BatchLocationsDB
 from db.batch_overrides import BatchOverrides as BatchOverridesDB
-from db.batches import Batches as BatchesDB
+# isort: on
+# fmt: on
 from db.beers import Beers as BeersDB
 from db.image_transitions import ImageTransitions as ImageTransitionsDB
 from db.on_tap import OnTap as OnTapDB

--- a/api/routers/beers.py
+++ b/api/routers/beers.py
@@ -5,7 +5,12 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from db.batch_locations import BatchLocations as BatchLocationsDB
+from db.batch_overrides import BatchOverrides as BatchOverridesDB
+from db.batches import Batches as BatchesDB
 from db.beers import Beers as BeersDB
+from db.image_transitions import ImageTransitions as ImageTransitionsDB
+from db.on_tap import OnTap as OnTapDB
 from dependencies.auth import AuthUser, get_db_session, require_user
 from lib import logging
 from schemas.beers import BeerCreate, BeerUpdate
@@ -121,11 +126,28 @@ async def delete_beer(
     current_user: AuthUser = Depends(require_user),
     db_session: AsyncSession = Depends(get_db_session),
 ):
-    """Delete a beer"""
+    """Delete a beer, cascading to archived batches only"""
     beer = await BeersDB.get_by_pkey(db_session, beer_id)
 
     if not beer:
         raise HTTPException(status_code=404, detail="Beer not found")
 
+    batches = await BatchesDB.query(db_session, beer_id=beer_id)
+    active_batches = [b for b in batches if b.archived_on is None]
+    if active_batches:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot delete beer with {len(active_batches)} active batch(es). Archive all batches before deleting.",
+        )
+
+    for batch in batches:
+        await BatchLocationsDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
+        await OnTapDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
+        await BatchOverridesDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
+
+    if batches:
+        await BatchesDB.delete_by(db_session, beer_id=beer_id, autocommit=False)
+
+    await ImageTransitionsDB.delete_by(db_session, beer_id=beer_id, autocommit=False)
     await BeersDB.delete(db_session, beer.id)
     return

--- a/api/routers/beverages.py
+++ b/api/routers/beverages.py
@@ -5,9 +5,13 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# isort: off
+# fmt: off
+from db.batches import Batches as BatchesDB  # pylint: disable=wrong-import-position
 from db.batch_locations import BatchLocations as BatchLocationsDB
 from db.batch_overrides import BatchOverrides as BatchOverridesDB
-from db.batches import Batches as BatchesDB
+# isort: on
+# fmt: on
 from db.beverages import Beverages as BeveragesDB
 from db.image_transitions import ImageTransitions as ImageTransitionsDB
 from db.on_tap import OnTap as OnTapDB

--- a/api/routers/beverages.py
+++ b/api/routers/beverages.py
@@ -15,6 +15,7 @@ from dependencies.auth import AuthUser, get_db_session, require_user
 from lib import logging
 from schemas.beverages import BeverageCreate, BeverageUpdate
 from services.beverages import BeverageService
+from services.taps import TapService
 
 router = APIRouter(prefix="/api/v1/beverages", tags=["beverages"])
 LOGGER = logging.getLogger(__name__)
@@ -121,6 +122,7 @@ async def delete_beverage(
         )
 
     for batch in batches:
+        await TapService.clear_on_tap_references_for_batch(db_session, batch.id, autocommit=False)
         await BatchLocationsDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
         await OnTapDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
         await BatchOverridesDB.delete_by(db_session, batch_id=batch.id, autocommit=False)

--- a/api/routers/beverages.py
+++ b/api/routers/beverages.py
@@ -5,7 +5,12 @@ from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from db.batch_locations import BatchLocations as BatchLocationsDB
+from db.batch_overrides import BatchOverrides as BatchOverridesDB
+from db.batches import Batches as BatchesDB
 from db.beverages import Beverages as BeveragesDB
+from db.image_transitions import ImageTransitions as ImageTransitionsDB
+from db.on_tap import OnTap as OnTapDB
 from dependencies.auth import AuthUser, get_db_session, require_user
 from lib import logging
 from schemas.beverages import BeverageCreate, BeverageUpdate
@@ -101,11 +106,28 @@ async def delete_beverage(
     current_user: AuthUser = Depends(require_user),
     db_session: AsyncSession = Depends(get_db_session),
 ):
-    """Delete a beverage (requires authentication)"""
+    """Delete a beverage, cascading to archived batches only"""
     beverage = await BeveragesDB.get_by_pkey(db_session, beverage_id)
 
     if not beverage:
         raise HTTPException(status_code=404, detail="Beverage not found")
 
+    batches = await BatchesDB.query(db_session, beverage_id=beverage_id)
+    active_batches = [b for b in batches if b.archived_on is None]
+    if active_batches:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Cannot delete beverage with {len(active_batches)} active batch(es). Archive all batches before deleting.",
+        )
+
+    for batch in batches:
+        await BatchLocationsDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
+        await OnTapDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
+        await BatchOverridesDB.delete_by(db_session, batch_id=batch.id, autocommit=False)
+
+    if batches:
+        await BatchesDB.delete_by(db_session, beverage_id=beverage_id, autocommit=False)
+
+    await ImageTransitionsDB.delete_by(db_session, beverage_id=beverage_id, autocommit=False)
     await BeveragesDB.delete(db_session, beverage.id)
     return

--- a/api/services/taps.py
+++ b/api/services/taps.py
@@ -2,6 +2,7 @@
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from db.taps import Taps as TapsDB
 from lib import logging
 from lib.tap_monitors import get_tap_monitor_lib
 from services.base import transform_dict_to_camel_case
@@ -11,6 +12,14 @@ LOGGER = logging.getLogger(__name__)
 
 class TapService:
     """Service for tap-related operations"""
+
+    @staticmethod
+    async def clear_on_tap_references_for_batch(db_session: AsyncSession, batch_id, autocommit=True):
+        """Clear taps.on_tap_id before deleting on_tap rows for a batch."""
+        taps = await TapsDB.get_by_batch(db_session, batch_id=batch_id)
+        for tap in taps:
+            if tap.on_tap_id:
+                await TapsDB.update(db_session, tap.id, on_tap_id=None, autocommit=autocommit)
 
     @staticmethod
     async def transform_tap_response(tap, db_session: AsyncSession, include_location=True, include_tap_monitor=False):

--- a/api/tests/unit/routers/test_beers.py
+++ b/api/tests/unit/routers/test_beers.py
@@ -247,14 +247,47 @@ class TestDeleteBeer:
         mock_auth_user = create_mock_auth_user()
         mock_session = AsyncMock()
         mock_beer = create_mock_beer()
+        mock_batch = MagicMock()
+        mock_batch.id = "batch-1"
+        mock_batch.archived_on = "2024-01-01"
 
-        with patch("routers.beers.BeersDB") as mock_db:
-            mock_db.get_by_pkey = AsyncMock(return_value=mock_beer)
-            mock_db.delete = AsyncMock()
+        with patch("routers.beers.BeersDB") as mock_beers_db, patch("routers.beers.BatchesDB") as mock_batches_db, patch(
+            "routers.beers.TapService.clear_on_tap_references_for_batch", new_callable=AsyncMock
+        ) as mock_clear_taps, patch("routers.beers.BatchLocationsDB.delete_by", new_callable=AsyncMock), patch(
+            "routers.beers.OnTapDB.delete_by", new_callable=AsyncMock
+        ), patch(
+            "routers.beers.BatchOverridesDB.delete_by", new_callable=AsyncMock
+        ), patch(
+            "routers.beers.ImageTransitionsDB.delete_by", new_callable=AsyncMock
+        ):
+            mock_beers_db.get_by_pkey = AsyncMock(return_value=mock_beer)
+            mock_beers_db.delete = AsyncMock()
+            mock_batches_db.query = AsyncMock(return_value=[mock_batch])
+            mock_batches_db.delete_by = AsyncMock()
 
-            result = run_async(delete_beer("beer-1", mock_auth_user, mock_session))
+            run_async(delete_beer("beer-1", mock_auth_user, mock_session))
 
-            mock_db.delete.assert_called_once()
+            mock_clear_taps.assert_called_once_with(mock_session, "batch-1", autocommit=False)
+            mock_beers_db.delete.assert_called_once()
+
+    def test_raises_409_when_active_batches_exist(self):
+        """Test raises 409 when beer has active batches"""
+        from routers.beers import delete_beer
+
+        mock_auth_user = create_mock_auth_user()
+        mock_session = AsyncMock()
+        mock_beer = create_mock_beer()
+        mock_batch = MagicMock()
+        mock_batch.archived_on = None
+
+        with patch("routers.beers.BeersDB") as mock_beers_db, patch("routers.beers.BatchesDB") as mock_batches_db:
+            mock_beers_db.get_by_pkey = AsyncMock(return_value=mock_beer)
+            mock_batches_db.query = AsyncMock(return_value=[mock_batch])
+
+            with pytest.raises(HTTPException) as exc_info:
+                run_async(delete_beer("beer-1", mock_auth_user, mock_session))
+
+            assert exc_info.value.status_code == 409
 
     def test_raises_404_when_not_found(self):
         """Test raises 404 when beer not found"""

--- a/api/tests/unit/routers/test_beverages.py
+++ b/api/tests/unit/routers/test_beverages.py
@@ -199,14 +199,47 @@ class TestDeleteBeverage:
         mock_auth_user = create_mock_auth_user()
         mock_session = AsyncMock()
         mock_beverage = create_mock_beverage()
+        mock_batch = MagicMock()
+        mock_batch.id = "batch-1"
+        mock_batch.archived_on = "2024-01-01"
 
-        with patch("routers.beverages.BeveragesDB") as mock_db:
-            mock_db.get_by_pkey = AsyncMock(return_value=mock_beverage)
-            mock_db.delete = AsyncMock()
+        with patch("routers.beverages.BeveragesDB") as mock_beverages_db, patch("routers.beverages.BatchesDB") as mock_batches_db, patch(
+            "routers.beverages.TapService.clear_on_tap_references_for_batch", new_callable=AsyncMock
+        ) as mock_clear_taps, patch("routers.beverages.BatchLocationsDB.delete_by", new_callable=AsyncMock), patch(
+            "routers.beverages.OnTapDB.delete_by", new_callable=AsyncMock
+        ), patch(
+            "routers.beverages.BatchOverridesDB.delete_by", new_callable=AsyncMock
+        ), patch(
+            "routers.beverages.ImageTransitionsDB.delete_by", new_callable=AsyncMock
+        ):
+            mock_beverages_db.get_by_pkey = AsyncMock(return_value=mock_beverage)
+            mock_beverages_db.delete = AsyncMock()
+            mock_batches_db.query = AsyncMock(return_value=[mock_batch])
+            mock_batches_db.delete_by = AsyncMock()
 
-            result = run_async(delete_beverage("bev-1", mock_auth_user, mock_session))
+            run_async(delete_beverage("bev-1", mock_auth_user, mock_session))
 
-            mock_db.delete.assert_called_once()
+            mock_clear_taps.assert_called_once_with(mock_session, "batch-1", autocommit=False)
+            mock_beverages_db.delete.assert_called_once()
+
+    def test_raises_409_when_active_batches_exist(self):
+        """Test raises 409 when beverage has active batches"""
+        from routers.beverages import delete_beverage
+
+        mock_auth_user = create_mock_auth_user()
+        mock_session = AsyncMock()
+        mock_beverage = create_mock_beverage()
+        mock_batch = MagicMock()
+        mock_batch.archived_on = None
+
+        with patch("routers.beverages.BeveragesDB") as mock_beverages_db, patch("routers.beverages.BatchesDB") as mock_batches_db:
+            mock_beverages_db.get_by_pkey = AsyncMock(return_value=mock_beverage)
+            mock_batches_db.query = AsyncMock(return_value=[mock_batch])
+
+            with pytest.raises(HTTPException) as exc_info:
+                run_async(delete_beverage("bev-1", mock_auth_user, mock_session))
+
+            assert exc_info.value.status_code == 409
 
     def test_raises_404_when_not_found(self):
         """Test raises 404 when beverage not found"""

--- a/api/tests/unit/services/test_taps.py
+++ b/api/tests/unit/services/test_taps.py
@@ -247,3 +247,39 @@ class TestTapServiceTransformResponse:
             result = run_async(TapService.transform_response(mock_tap, mock_session, include_location=False, filter_unsupported_tap_monitor=True))
 
         assert "tapMonitor" not in result
+
+
+class TestClearOnTapReferencesForBatch:
+    """Tests for TapService.clear_on_tap_references_for_batch"""
+
+    def test_clears_on_tap_id_for_matching_taps(self):
+        """Test clears on_tap_id for taps still referencing the batch"""
+        mock_session = AsyncMock()
+        mock_tap = MagicMock()
+        mock_tap.id = "tap-1"
+        mock_tap.on_tap_id = "on-tap-1"
+
+        with patch("services.taps.TapsDB.get_by_batch", new_callable=AsyncMock) as mock_get_by_batch, patch(
+            "services.taps.TapsDB.update", new_callable=AsyncMock
+        ) as mock_update:
+            mock_get_by_batch.return_value = [mock_tap]
+
+            run_async(TapService.clear_on_tap_references_for_batch(mock_session, "batch-1", autocommit=False))
+
+            mock_update.assert_called_once_with(mock_session, "tap-1", on_tap_id=None, autocommit=False)
+
+    def test_skips_taps_without_on_tap_id(self):
+        """Test does not update taps that have no on_tap_id"""
+        mock_session = AsyncMock()
+        mock_tap = MagicMock()
+        mock_tap.id = "tap-1"
+        mock_tap.on_tap_id = None
+
+        with patch("services.taps.TapsDB.get_by_batch", new_callable=AsyncMock) as mock_get_by_batch, patch(
+            "services.taps.TapsDB.update", new_callable=AsyncMock
+        ) as mock_update:
+            mock_get_by_batch.return_value = [mock_tap]
+
+            run_async(TapService.clear_on_tap_references_for_batch(mock_session, "batch-1"))
+
+            mock_update.assert_not_called()

--- a/api/tests/unit/test_api.py
+++ b/api/tests/unit/test_api.py
@@ -256,7 +256,7 @@ class TestFastAPIAppConfiguration:
     def test_api_has_version(self, api_module):
         """Test API has version set"""
         assert api_module.api.version is not None
-        assert api_module.api.version == "0.8.2"
+        assert api_module.api.version == "0.8.3"
 
     def test_api_has_docs_url(self, api_module):
         """Test API has docs URL configured"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ markers = [
 
 [tool.poetry]
 name = "brewhouse-manager"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["alanquillin"]
 description = "Brewhouse Manager"
 package-mode = false

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brewhouse-manager",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/ui/src/app/manage/beer/beer.component.spec.ts
+++ b/ui/src/app/manage/beer/beer.component.spec.ts
@@ -454,7 +454,7 @@ describe('ManageBeerComponent', () => {
     beforeEach(() => {
       fixture.detectChanges();
       mockDataService.deleteBeer.and.returnValue(of({}));
-      component.beerBatches = { 'beer-1': [] };
+      mockDataService.getBeerBatches.and.returnValue(of([]));
     });
 
     it('should call deleteBeer when confirmed', () => {
@@ -463,6 +463,7 @@ describe('ManageBeerComponent', () => {
 
       component.deleteBeer(beer);
 
+      expect(mockDataService.getBeerBatches).toHaveBeenCalledWith('beer-1', false, true);
       expect(mockDataService.deleteBeer).toHaveBeenCalledWith('beer-1');
     });
 
@@ -472,6 +473,36 @@ describe('ManageBeerComponent', () => {
 
       component.deleteBeer(beer);
 
+      expect(mockDataService.deleteBeer).not.toHaveBeenCalled();
+    });
+
+    it('should include archived batch count in confirm when cache omits archived batches', () => {
+      mockDataService.getBeerBatches.and.returnValue(
+        of([{ id: 'batch-1', archivedOn: '2024-01-01' }] as any)
+      );
+      component.beerBatches = { 'beer-1': [] };
+      const confirmSpy = spyOn(window, 'confirm').and.returnValue(false);
+      const beer = new Beer(mockBeers[0]);
+
+      component.deleteBeer(beer);
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/permanently delete 1 archived batch\(es\)/)
+      );
+    });
+
+    it('should block delete when active batches exist', () => {
+      mockDataService.getBeerBatches.and.returnValue(of([{ id: 'batch-1' }] as any));
+      spyOn(window, 'confirm');
+      spyOn(component, 'displayError');
+      const beer = new Beer(mockBeers[0]);
+
+      component.deleteBeer(beer);
+
+      expect(component.displayError).toHaveBeenCalledWith(
+        jasmine.stringMatching(/1 active batch\(es\)/)
+      );
+      expect(window.confirm).not.toHaveBeenCalled();
       expect(mockDataService.deleteBeer).not.toHaveBeenCalled();
     });
   });

--- a/ui/src/app/manage/beer/beer.component.ts
+++ b/ui/src/app/manage/beer/beer.component.ts
@@ -528,12 +528,6 @@ export class ManageBeerComponent implements OnInit {
     }
   }
 
-  beerBatchesAssocTaps(_: Beer): string[] {
-    const tapIds: string[] = [];
-
-    return tapIds;
-  }
-
   clearNextTap(tapIds: string[], next: () => void, error: (err: DataError) => void): void {
     if (isNilOrEmpty(tapIds)) return next();
 

--- a/ui/src/app/manage/beer/beer.component.ts
+++ b/ui/src/app/manage/beer/beer.component.ts
@@ -507,29 +507,24 @@ export class ManageBeerComponent implements OnInit {
   }
 
   deleteBeer(beer: Beer): void {
-    if (confirm(`Are you sure you want to delete beer '${beer.getName()}'?`)) {
+    const batches = this.beerBatches[beer.id] ?? [];
+    const activeBatches = batches.filter(b => isNilOrEmpty(b.archivedOn));
+    if (activeBatches.length > 0) {
+      this.displayError(
+        `Cannot delete '${beer.getName()}': it has ${activeBatches.length} active batch(es). Archive all batches before deleting.`
+      );
+      return;
+    }
+
+    const archivedCount = batches.length;
+    const batchWarning =
+      archivedCount > 0
+        ? ` This will also permanently delete ${archivedCount} archived batch(es).`
+        : '';
+
+    if (confirm(`Are you sure you want to delete beer '${beer.getName()}'?${batchWarning}`)) {
       this.processing = true;
-      const tapIds = this.beerBatchesAssocTaps(beer);
-      if (!isNilOrEmpty(tapIds)) {
-        if (
-          confirm(
-            `The beer has 1 or more batch associated with one or more taps.  Batches must first be cleared from the tap(s) before deleting. Proceed?`
-          )
-        ) {
-          this.clearNextTap(
-            tapIds,
-            () => {
-              this._deleteBeer(beer);
-            },
-            (err: DataError) => {
-              this.displayError(err.message);
-              this.processing = false;
-            }
-          );
-        }
-      } else {
-        this._deleteBeer(beer);
-      }
+      this._deleteBeer(beer);
     }
   }
 

--- a/ui/src/app/manage/beer/beer.component.ts
+++ b/ui/src/app/manage/beer/beer.component.ts
@@ -507,25 +507,31 @@ export class ManageBeerComponent implements OnInit {
   }
 
   deleteBeer(beer: Beer): void {
-    const batches = this.beerBatches[beer.id] ?? [];
-    const activeBatches = batches.filter(b => isNilOrEmpty(b.archivedOn));
-    if (activeBatches.length > 0) {
-      this.displayError(
-        `Cannot delete '${beer.getName()}': it has ${activeBatches.length} active batch(es). Archive all batches before deleting.`
-      );
-      return;
-    }
+    this.dataService.getBeerBatches(beer.id, false, true).subscribe({
+      next: (batches: Batch[]) => {
+        const activeBatches = batches.filter(b => isNilOrEmpty(b.archivedOn));
+        if (activeBatches.length > 0) {
+          this.displayError(
+            `Cannot delete '${beer.getName()}': it has ${activeBatches.length} active batch(es). Archive all batches before deleting.`
+          );
+          return;
+        }
 
-    const archivedCount = batches.length;
-    const batchWarning =
-      archivedCount > 0
-        ? ` This will also permanently delete ${archivedCount} archived batch(es).`
-        : '';
+        const archivedCount = batches.length;
+        const batchWarning =
+          archivedCount > 0
+            ? ` This will also permanently delete ${archivedCount} archived batch(es).`
+            : '';
 
-    if (confirm(`Are you sure you want to delete beer '${beer.getName()}'?${batchWarning}`)) {
-      this.processing = true;
-      this._deleteBeer(beer);
-    }
+        if (confirm(`Are you sure you want to delete beer '${beer.getName()}'?${batchWarning}`)) {
+          this.processing = true;
+          this._deleteBeer(beer);
+        }
+      },
+      error: (err: DataError) => {
+        this.displayError(err.message);
+      },
+    });
   }
 
   clearNextTap(tapIds: string[], next: () => void, error: (err: DataError) => void): void {

--- a/ui/src/app/manage/beverage/beverage.component.spec.ts
+++ b/ui/src/app/manage/beverage/beverage.component.spec.ts
@@ -471,7 +471,7 @@ describe('ManageBeverageComponent', () => {
     beforeEach(() => {
       fixture.detectChanges();
       mockDataService.deleteBeverage.and.returnValue(of({}));
-      component.beverageBatches = { 'bev-1': [] };
+      mockDataService.getBeverageBatches.and.returnValue(of([]));
     });
 
     it('should call deleteBeverage when confirmed', () => {
@@ -480,6 +480,7 @@ describe('ManageBeverageComponent', () => {
 
       component.deleteBeverage(beverage);
 
+      expect(mockDataService.getBeverageBatches).toHaveBeenCalledWith('bev-1', false, true);
       expect(mockDataService.deleteBeverage).toHaveBeenCalledWith('bev-1');
     });
 
@@ -489,6 +490,36 @@ describe('ManageBeverageComponent', () => {
 
       component.deleteBeverage(beverage);
 
+      expect(mockDataService.deleteBeverage).not.toHaveBeenCalled();
+    });
+
+    it('should include archived batch count in confirm when cache omits archived batches', () => {
+      mockDataService.getBeverageBatches.and.returnValue(
+        of([{ id: 'batch-1', archivedOn: '2024-01-01' }] as any)
+      );
+      component.beverageBatches = { 'bev-1': [] };
+      const confirmSpy = spyOn(window, 'confirm').and.returnValue(false);
+      const beverage = new Beverage(mockBeverages[0]);
+
+      component.deleteBeverage(beverage);
+
+      expect(confirmSpy).toHaveBeenCalledWith(
+        jasmine.stringMatching(/permanently delete 1 archived batch\(es\)/)
+      );
+    });
+
+    it('should block delete when active batches exist', () => {
+      mockDataService.getBeverageBatches.and.returnValue(of([{ id: 'batch-1' }] as any));
+      spyOn(window, 'confirm');
+      spyOn(component, 'displayError');
+      const beverage = new Beverage(mockBeverages[0]);
+
+      component.deleteBeverage(beverage);
+
+      expect(component.displayError).toHaveBeenCalledWith(
+        jasmine.stringMatching(/1 active batch\(es\)/)
+      );
+      expect(window.confirm).not.toHaveBeenCalled();
       expect(mockDataService.deleteBeverage).not.toHaveBeenCalled();
     });
   });

--- a/ui/src/app/manage/beverage/beverage.component.ts
+++ b/ui/src/app/manage/beverage/beverage.component.ts
@@ -413,25 +413,33 @@ export class ManageBeverageComponent implements OnInit {
   }
 
   deleteBeverage(beverage: Beverage): void {
-    const batches = this.beverageBatches[beverage.id] ?? [];
-    const activeBatches = batches.filter(b => isNilOrEmpty(b.archivedOn));
-    if (activeBatches.length > 0) {
-      this.displayError(
-        `Cannot delete '${beverage.name}': it has ${activeBatches.length} active batch(es). Archive all batches before deleting.`
-      );
-      return;
-    }
+    this.dataService.getBeverageBatches(beverage.id, false, true).subscribe({
+      next: (batches: Batch[]) => {
+        const activeBatches = batches.filter(b => isNilOrEmpty(b.archivedOn));
+        if (activeBatches.length > 0) {
+          this.displayError(
+            `Cannot delete '${beverage.name}': it has ${activeBatches.length} active batch(es). Archive all batches before deleting.`
+          );
+          return;
+        }
 
-    const archivedCount = batches.length;
-    const batchWarning =
-      archivedCount > 0
-        ? ` This will also permanently delete ${archivedCount} archived batch(es).`
-        : '';
+        const archivedCount = batches.length;
+        const batchWarning =
+          archivedCount > 0
+            ? ` This will also permanently delete ${archivedCount} archived batch(es).`
+            : '';
 
-    if (confirm(`Are you sure you want to delete beverage '${beverage.name}'?${batchWarning}`)) {
-      this.processing = true;
-      this._deleteBeverage(beverage);
-    }
+        if (
+          confirm(`Are you sure you want to delete beverage '${beverage.name}'?${batchWarning}`)
+        ) {
+          this.processing = true;
+          this._deleteBeverage(beverage);
+        }
+      },
+      error: (err: DataError) => {
+        this.displayError(err.message);
+      },
+    });
   }
 
   clearNextTap(tapIds: string[], next: () => void, error: (err: DataError) => void): void {

--- a/ui/src/app/manage/beverage/beverage.component.ts
+++ b/ui/src/app/manage/beverage/beverage.component.ts
@@ -413,29 +413,24 @@ export class ManageBeverageComponent implements OnInit {
   }
 
   deleteBeverage(beverage: Beverage): void {
-    if (confirm(`Are you sure you want to delete beverage '${beverage.name}'?`)) {
+    const batches = this.beverageBatches[beverage.id] ?? [];
+    const activeBatches = batches.filter(b => isNilOrEmpty(b.archivedOn));
+    if (activeBatches.length > 0) {
+      this.displayError(
+        `Cannot delete '${beverage.name}': it has ${activeBatches.length} active batch(es). Archive all batches before deleting.`
+      );
+      return;
+    }
+
+    const archivedCount = batches.length;
+    const batchWarning =
+      archivedCount > 0
+        ? ` This will also permanently delete ${archivedCount} archived batch(es).`
+        : '';
+
+    if (confirm(`Are you sure you want to delete beverage '${beverage.name}'?${batchWarning}`)) {
       this.processing = true;
-      const tapIds = this.beverageBatchesAssocTaps(beverage);
-      if (!isNilOrEmpty(tapIds)) {
-        if (
-          confirm(
-            `The beverage has 1 or more batch(es) associated with one or more taps.  Batches must first be cleared from the tap(s) before deleting. Proceed?`
-          )
-        ) {
-          this.clearNextTap(
-            tapIds,
-            () => {
-              this._deleteBeverage(beverage);
-            },
-            (err: DataError) => {
-              this.displayError(err.message);
-              this.processing = false;
-            }
-          );
-        }
-      } else {
-        this._deleteBeverage(beverage);
-      }
+      this._deleteBeverage(beverage);
     }
   }
 

--- a/ui/src/app/manage/beverage/beverage.component.ts
+++ b/ui/src/app/manage/beverage/beverage.component.ts
@@ -434,12 +434,6 @@ export class ManageBeverageComponent implements OnInit {
     }
   }
 
-  beverageBatchesAssocTaps(_beverage: Beverage): string[] {
-    const tapIds: string[] = [];
-
-    return tapIds;
-  }
-
   clearNextTap(tapIds: string[], next: () => void, error: (err: DataError) => void): void {
     if (isNilOrEmpty(tapIds)) return next();
 

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  appVersion: '0.8.2',
+  appVersion: '0.8.3',
 };


### PR DESCRIPTION
Version branch for v0.8.3.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deletes now touch taps, batches, and multiple related tables in one flow; incorrect cascade or missing transaction boundaries could leave inconsistent tap/batch state.
> 
> **Overview**
> Releases **v0.8.3** and tightens how beers and beverages are deleted end-to-end.
> 
> **API:** `DELETE` for beers and beverages now returns **409** when any **active** (non-archived) batches remain. When only archived batches exist, delete **cascades**: clears tap `on_tap_id` references via new `TapService.clear_on_tap_references_for_batch`, then removes batch-related rows (`on_tap`, locations, overrides), batches, image transitions, and the parent record.
> 
> **UI:** Manage beer/beverage delete loads all batches first, blocks delete with an error if active batches exist, and confirms when archived batches will be **permanently** removed—replacing the prior manual tap-clearing flow before delete.
> 
> Unit tests cover the new API behavior, tap reference clearing, and UI confirm/error paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8f8b74b72ebadbd8536c133b1ea8eff78fa3d7b1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->