### PR TITLE
Remove perl from container image to address CVEs (v0.8.4)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -168,6 +168,19 @@ This is defined locally in each test file that uses it.
 
 **Auth dependency chain**: `get_optional_user()` → `require_user()` (401) → `require_admin()` (403)
 
+**Beer/beverage delete cascade pattern**: Deleting a beer or beverage requires a specific multi-step manual cascade (database FKs have no `ON DELETE CASCADE` at the DB level — it's all application-enforced). The correct order, all with `autocommit=False` until the final step:
+
+1. Check for active batches (`archived_on IS NULL`) — raise 409 if any exist
+2. For each archived batch: `TapService.clear_on_tap_references_for_batch(session, batch.id, autocommit=False)` — nulls `taps.on_tap_id` before on_tap rows are deleted
+3. `BatchLocationsDB.delete_by(session, batch_id=..., autocommit=False)`
+4. `OnTapDB.delete_by(session, batch_id=..., autocommit=False)`
+5. `BatchOverridesDB.delete_by(session, batch_id=..., autocommit=False)`
+6. `BatchesDB.delete_by(session, beer_id=..., autocommit=False)` (or `beverage_id=...`)
+7. `ImageTransitionsDB.delete_by(session, beer_id=..., autocommit=False)`
+8. `BeersDB.delete(session, beer.id)` — default `autocommit=True` commits the whole transaction
+
+`TapService.clear_on_tap_references_for_batch` is in `api/services/taps.py`.
+
 **Config**: `Config` singleton, reads `config/default.json` + env vars with type conversion schema. Access via `CONFIG.get("dotted.key.path")`.
 
 ### Frontend
@@ -199,6 +212,8 @@ constructor(private dataService: DataService) {}
 ```typescript
 const freshService = TestBed.runInInjectionContext(() => new MyService());
 ```
+
+**Delete beer/beverage UI pattern**: `deleteBeer` / `deleteBeverage` check local `beerBatches[beer.id]` / `beverageBatches[beverage.id]` data *before* calling the API. If any batch has no `archivedOn` (active), call `displayError()` and return without hitting the API. If all batches are archived, include the count in the `confirm()` message. The backend also enforces the same rule (returns 409), so the UI check is a fast-fail UX convenience, not the only guard.
 
 **`beverageBatches` / `beerBatches` lookup gotcha**: These maps only contain entries for existing (already-saved) entities. When the add flow is active, `modifyBeverage.id` / `modifyBeer.id` is `undefined`, so `beverageBatches[undefined]` is `undefined` — accessing `.length` on it will throw. Always guard template lookups with optional chaining:
 ```html
@@ -265,6 +280,24 @@ beverage = relationship(beverages.Beverages, back_populates="batches")
 ```
 
 This has been applied to: `Beers.batches` ↔ `Batches.beer`, `Beverages.batches` ↔ `Batches.beverage`.
+
+### Circular import: `db.batches` must be imported before `db.batch_locations`
+
+`batches.py` accesses `batch_locations.BatchLocations.__table__` at class-definition time (inside the `locations` secondary `relationship`). If any router imports `db.batch_locations` *before* `db.batches`, Python raises `AttributeError: partially initialized module 'db.batch_locations' has no attribute 'BatchLocations'`.
+
+Fix: guard the import order with `# isort: off/on` in any router that imports both:
+
+```python
+# isort: off
+# fmt: off
+from db.batches import Batches as BatchesDB  # pylint: disable=wrong-import-position
+from db.batch_locations import BatchLocations as BatchLocationsDB
+from db.batch_overrides import BatchOverrides as BatchOverridesDB
+# isort: on
+# fmt: on
+```
+
+This pattern already appears in `routers/batches.py` and was added to `routers/beers.py` and `routers/beverages.py`. Isort would otherwise sort `batch_locations` before `batches` alphabetically.
 
 ### Secondary (many-to-many) + direct FK relationships on the same table
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -231,6 +231,39 @@ const freshService = TestBed.runInInjectionContext(() => new MyService());
 
 Enabled/disabled via config: `tap_monitors.<type>.enabled`.
 
+## Docker Build Notes
+
+### Multi-stage layout
+
+The final runtime image inherits solely from `python-base` (`python:3.12-slim-trixie`). The `node-base` / `node-build` stages are compile-only — they produce the Angular static files copied into the final image via `COPY --from=node-build`. Packages installed in the node stages (including perl) are discarded and do not appear in the final image layers. Only the `python-base` stage matters for CVE scanning of the shipped container.
+
+### Removing perl (CVE remediation)
+
+`build-essential` (installed in `python-base` for compiling Python packages) pulls `perl` and `perl-base` in as dependencies. They are not needed at runtime. Removing them requires:
+
+1. **`--allow-remove-essential`** — `perl-base` is marked essential in Debian; apt refuses to purge it without this flag.  
+2. This flag is safe in `python-base` because the purge is the **last `apt-get` operation** in the stage and nothing in the runtime app depends on perl.  
+3. Do **not** attempt to purge perl from `node-base` — the non-slim Node image has many packages (e.g. `x11-common`, `ucf`) whose post-removal scripts are written in Perl; removing `perl-base` there causes `dpkg` errors during the build.
+
+### `addgroup` vs `groupadd`
+
+`addgroup` (from the Debian `adduser` package) is a **Perl script**. After `perl-base` is removed from `python-base`, calling `addgroup` in the `final` stage (which inherits from `python-base`) will fail with `addgroup: not found`.
+
+Use `groupadd` instead — it is a C binary from the `shadow` package and does not require perl:
+
+```dockerfile
+# Correct (C binary, no perl dependency)
+RUN groupadd --gid 10000 app && \
+    useradd --gid app --shell /sbin/nologin --no-create-home --uid 10000 app
+
+# Wrong after perl removal (Perl script)
+RUN addgroup app --gid 10000 && useradd ...
+```
+
+### `libpq-dev` auto-removal
+
+`libpq-dev` is installed in `python-base` alongside the build tools but is auto-removed as a cascade side-effect: `libpq-dev` depends on `libssl-dev`, and purging `libssl-dev` causes apt to remove `libpq-dev` as a broken dependent. This is safe because `psycopg2-binary` bundles its own `libpq.so` and does not require the system library at runtime.
+
 ## CI
 
 GitHub Actions workflow (`.github/workflows/ci.yml`) runs on PRs to `main`:

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-interaction --no-ansi --only main --no-root
 RUN poetry run pip install psycopg2-binary
 
-RUN apt-get purge -y --auto-remove gcc build-essential libffi-dev libssl-dev
+RUN apt-get purge -y --auto-remove --allow-remove-essential gcc build-essential libffi-dev libssl-dev perl perl-base
 
 
 # Angular build
@@ -46,7 +46,7 @@ ENV PYTHONUNBUFFERED=1
 ENV CONFIG_BASE_DIR=/brewhouse-manager/config
 ENV RUN_ENV=${build_for}
 
-RUN addgroup app --gid 10000 && \
+RUN groupadd --gid 10000 app && \
     useradd --gid app \
             --shell /sbin/nologin \
             --no-create-home \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,10 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-interaction --no-ansi --only main --no-root
 RUN poetry run pip install psycopg2-binary
 
+# --allow-remove-essential is required because perl-base is marked essential in Debian.
+# It is safe here: this is the last apt operation in the stage, the final image inherits
+# from this stage, and nothing in the runtime app (Python/FastAPI) depends on perl.
+# perl and perl-base are removed to remediate CVEs in debian/perl (e.g. 5.40.1-6).
 RUN apt-get purge -y --auto-remove --allow-remove-essential gcc build-essential libffi-dev libssl-dev perl perl-base
 
 

--- a/api/api.py
+++ b/api/api.py
@@ -27,7 +27,7 @@ if not _secret_key:
 # Create FastAPI app
 api = FastAPI(
     title="Brewhouse Manager",
-    version="0.8.3",
+    version="0.8.4",
     docs_url="/api/docs",
     redoc_url="/api/redoc" if CONFIG.get("ENV") == "development" else None,
 )

--- a/api/tests/unit/test_api.py
+++ b/api/tests/unit/test_api.py
@@ -256,7 +256,7 @@ class TestFastAPIAppConfiguration:
     def test_api_has_version(self, api_module):
         """Test API has version set"""
         assert api_module.api.version is not None
-        assert api_module.api.version == "0.8.3"
+        assert api_module.api.version == "0.8.4"
 
     def test_api_has_docs_url(self, api_module):
         """Test API has docs URL configured"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ markers = [
 
 [tool.poetry]
 name = "brewhouse-manager"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["alanquillin"]
 description = "Brewhouse Manager"
 package-mode = false

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "brewhouse-manager",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/ui/src/environments/environment.prod.ts
+++ b/ui/src/environments/environment.prod.ts
@@ -1,4 +1,4 @@
 export const environment = {
   production: true,
-  appVersion: '0.8.3',
+  appVersion: '0.8.4',
 };


### PR DESCRIPTION
## Summary

- Removes `perl` and `perl-base` from the `python-base` Docker stage (which the final runtime image inherits from) to address critical/high CVEs in `debian/perl 5.40.1-6`
- Replaces `addgroup` (a Perl script) with `groupadd` (a C binary from the `shadow` package) since `perl-base` removal breaks the Perl-based `addgroup` command
- Bumps version to 0.8.4

## Details

The perl packages were pulled into the `python-base` stage as a dependency of `build-essential`. They are not needed at runtime and were not being cleaned up. The purge uses `--allow-remove-essential` because `perl-base` is marked as an essential Debian package; this is safe here since it is the last `apt-get` operation in that stage and nothing in the final image depends on perl.

The `node-base` stage (used only to build the Angular app) was left unchanged — its packages are discarded and never appear in the final image layers.

## Test plan

- [ ] `docker build` completes without errors
- [ ] CVE scanner no longer reports `debian/perl 5.40.1-6` findings for the final image
- [ ] App starts and serves correctly in the built container

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Image-layer changes affect production builds and user creation at container start; incorrect apt purge could break the image, though scope is limited to build tooling and documented follow-ups.
> 
> **Overview**
> **Removes `perl` / `perl-base` from the shipped container** by extending the `python-base` stage purge with `--allow-remove-essential` and explicit perl package removal, addressing Debian perl CVE findings while keeping the node build stages unchanged (they are not in the final image).
> 
> **Fixes the final image user setup** by replacing `addgroup` (Perl-based, broken after perl removal) with `groupadd` from the `shadow` package.
> 
> **Bumps release to 0.8.4** in FastAPI metadata, Poetry, UI `package.json`, and production `appVersion`, with the API version unit test updated to match.
> 
> **Expands `AGENTS.md`** with operational guidance: beer/beverage delete cascade order, delete UI fast-fail patterns, `beerBatches`/`beverageBatches` template guards, Docker multi-stage/CVE/`groupadd`/`libpq-dev` notes, and the `db.batches` before `db.batch_locations` import-order fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33da0cfaf14b0c2a4ef0c41ff7fce3610e4acbac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->