### PR TITLE
Remove poetry from final container layer (v0.8.4+)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,19 +235,33 @@ Enabled/disabled via config: `tap_monitors.<type>.enabled`.
 
 ### Multi-stage layout
 
-The final runtime image inherits solely from `python-base` (`python:3.12-slim-trixie`). The `node-base` / `node-build` stages are compile-only — they produce the Angular static files copied into the final image via `COPY --from=node-build`. Packages installed in the node stages (including perl) are discarded and do not appear in the final image layers. Only the `python-base` stage matters for CVE scanning of the shipped container.
+The build uses four stages:
+
+| Stage | Base | Purpose |
+|---|---|---|
+| `node-base` | `node:24.15-trixie` | Install pnpm/Angular CLI, install UI deps |
+| `python-build` | `python:3.12-slim-trixie` | Install Poetry + build tools, compile `.venv` |
+| `node-build` | `node-base` | Compile Angular app |
+| `final` | `python:3.12-slim-trixie` (clean) | Runtime image — copies `.venv` + app code only |
+
+**Poetry is not present in the final image.** It lives only in `python-build`. The `.venv` directory (at `/.venv` in the container) is the only Python artifact copied into `final` via `COPY --from=python-build /.venv /.venv`. This keeps poetry, its transitive deps (e.g. msgpack), build tools, and compilers out of the shipped image.
+
+Because poetry is absent at runtime, **all scripts that previously used `poetry run` must use the venv directly**:
+- `entrypoint.sh` activates the venv with `. /.venv/bin/activate` before calling `migrate.sh` and `python app.py`.
+- `api/migrate.sh` uses `ALEMBIC="alembic"` and `PYTHON="python"` (resolved from PATH after venv activation).
+- `deploy/docker-local/Dockerfile` CMD uses `. /.venv/bin/activate && ...` for the seed container.
+
+If a new script or service needs to run Python/alembic inside the container, use `/.venv/bin/python` or activate the venv — do not reinstall poetry.
 
 ### Removing perl (CVE remediation)
 
-`build-essential` (installed in `python-base` for compiling Python packages) pulls `perl` and `perl-base` in as dependencies. They are not needed at runtime. Removing them requires:
+`build-essential` (installed in `python-build` for compiling Python packages) pulls `perl` and `perl-base` in as dependencies. They are not needed at runtime and were previously removed from `python-base` (now `python-build`). This step is no longer necessary in `python-build` because `python-build` is a build-only stage — its layers do not ship. The `final` stage starts from a clean `python:3.12-slim-trixie` which does not include perl.
 
-1. **`--allow-remove-essential`** — `perl-base` is marked essential in Debian; apt refuses to purge it without this flag.  
-2. This flag is safe in `python-base` because the purge is the **last `apt-get` operation** in the stage and nothing in the runtime app depends on perl.  
-3. Do **not** attempt to purge perl from `node-base` — the non-slim Node image has many packages (e.g. `x11-common`, `ucf`) whose post-removal scripts are written in Perl; removing `perl-base` there causes `dpkg` errors during the build.
+Historical note: `--allow-remove-essential` was required to purge `perl-base` from a Debian-based stage because apt marks it essential. Do **not** attempt to purge perl from `node-base` — the non-slim Node image has many packages (e.g. `x11-common`, `ucf`) whose post-removal scripts are written in Perl; removing `perl-base` there causes `dpkg` errors during the build.
 
 ### `addgroup` vs `groupadd`
 
-`addgroup` (from the Debian `adduser` package) is a **Perl script**. After `perl-base` is removed from `python-base`, calling `addgroup` in the `final` stage (which inherits from `python-base`) will fail with `addgroup: not found`.
+`addgroup` (from the Debian `adduser` package) is a **Perl script**. It is not available in `python:3.12-slim-trixie` (which does not ship perl). Calling `addgroup` in the `final` stage will fail with `addgroup: not found`.
 
 Use `groupadd` instead — it is a C binary from the `shadow` package and does not require perl:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ The build uses four stages:
 
 Because poetry is absent at runtime, **all scripts that previously used `poetry run` must use the venv directly**:
 - `entrypoint.sh` activates the venv with `. /.venv/bin/activate` before calling `migrate.sh` and `python app.py`.
-- `api/migrate.sh` uses `ALEMBIC="alembic"` and `PYTHON="python"` (resolved from PATH after venv activation).
+- `api/migrate.sh` resolves `ALEMBIC` and `PYTHON` to `/.venv/bin/alembic` / `/.venv/bin/python` when those paths exist (i.e., inside the container), and falls back to bare commands for local dev where the venv is at a different path or already activated.
 - `deploy/docker-local/Dockerfile` CMD uses `. /.venv/bin/activate && ...` for the seed container.
 
 If a new script or service needs to run Python/alembic inside the container, use `/.venv/bin/python` or activate the venv — do not reinstall poetry.
@@ -274,9 +274,16 @@ RUN groupadd --gid 10000 app && \
 RUN addgroup app --gid 10000 && useradd ...
 ```
 
-### `libpq-dev` auto-removal
+### Runtime library assumptions in the final image
 
-`libpq-dev` is installed in `python-base` alongside the build tools but is auto-removed as a cascade side-effect: `libpq-dev` depends on `libssl-dev`, and purging `libssl-dev` causes apt to remove `libpq-dev` as a broken dependent. This is safe because `psycopg2-binary` bundles its own `libpq.so` and does not require the system library at runtime.
+The `final` stage has no `apt-get install` — it starts from a clean `python:3.12-slim-trixie` and only receives the `.venv`. Any C extension in the venv that dynamically links to a system library not present in the base image will fail at runtime with a "shared library not found" error.
+
+Currently safe because:
+- `psycopg2-binary` bundles its own `libpq.so` (no system `libpq5` needed).
+- `cryptography` downloads a manylinux wheel on Linux that statically bundles OpenSSL.
+- `libssl3` and `libffi8` are present in the Python base image (Python itself needs them).
+
+If a new dependency is added that links to a system library outside this set (e.g., `libpq5`, `libxml2`, `libcurl`), add the **runtime** package (not the `-dev` variant) to the `final` stage's `apt-get install`.
 
 ## CI
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,6 @@ COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-interaction --no-ansi --only main --no-root
 RUN poetry run pip install psycopg2-binary
 
-
 # Angular build
 # ############################################################
 FROM node-base AS node-build

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,28 +7,21 @@ COPY ui/angular.json ui/tsconfig.app.json ui/tsconfig.json ui/package.json ui/pn
 WORKDIR /ui
 RUN pnpm install --frozen-lockfile
 
-# Python base
+# Python build
 # ############################################################
-FROM python:3.12-slim-trixie AS python-base
+FROM python:3.12-slim-trixie AS python-build
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends gcc build-essential libpq-dev libffi-dev libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN pip install -U pip 
-RUN pip install setuptools wheel
+RUN pip install -U pip setuptools wheel
 RUN pip install "poetry>=2.4.1"
 
 RUN poetry config virtualenvs.in-project true
 COPY pyproject.toml poetry.lock ./
 RUN poetry install --no-interaction --no-ansi --only main --no-root
 RUN poetry run pip install psycopg2-binary
-
-# --allow-remove-essential is required because perl-base is marked essential in Debian.
-# It is safe here: this is the last apt operation in the stage, the final image inherits
-# from this stage, and nothing in the runtime app (Python/FastAPI) depends on perl.
-# perl and perl-base are removed to remediate CVEs in debian/perl (e.g. 5.40.1-6).
-RUN apt-get purge -y --auto-remove --allow-remove-essential gcc build-essential libffi-dev libssl-dev perl perl-base
 
 
 # Angular build
@@ -39,12 +32,11 @@ ARG build_for=prod
 COPY ui/src /ui/src
 RUN pnpm run build:${build_for}
 
-# Final build
+# Final image — no poetry, no build tools, no compiler
 # ############################################################
-FROM python-base AS final
+FROM python:3.12-slim-trixie AS final
 
 ARG build_for=prod
-
 
 ENV PYTHONUNBUFFERED=1
 ENV CONFIG_BASE_DIR=/brewhouse-manager/config
@@ -55,8 +47,8 @@ RUN groupadd --gid 10000 app && \
             --shell /sbin/nologin \
             --no-create-home \
             --uid 10000 app
-            
 
+COPY --from=python-build /.venv /.venv
 COPY --from=node-build /ui/dist/brewhouse-manager/browser /brewhouse-manager/api/static/
 
 COPY config /brewhouse-manager/config

--- a/Makefile
+++ b/Makefile
@@ -103,7 +103,7 @@ rebuild-db-seed:
 # Targets for publishing containers
 
 publish: ## Build and publish the Docker images
-	$(MAKE) build DOCKER_BUILD_ARGS+="--push"
+	$(MAKE) build DOCKER_BUILD_ARGS+="--attest type=provenance,mode=max --attest type=sbom,value=true --push"
 
 # Targets for running the app
 

--- a/api/migrate.sh
+++ b/api/migrate.sh
@@ -1,8 +1,25 @@
 #! /bin/bash
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+VENV_BIN=""
 if [ -f "/.venv/bin/alembic" ]; then
-    ALEMBIC="/.venv/bin/alembic"
-    PYTHON="/.venv/bin/python"
+    VENV_BIN="/.venv/bin"
+elif [ -f "${PROJECT_ROOT}/.venv/bin/alembic" ]; then
+    VENV_BIN="${PROJECT_ROOT}/.venv/bin"
+elif [ -n "${VIRTUAL_ENV}" ] && [ -f "${VIRTUAL_ENV}/bin/alembic" ]; then
+    VENV_BIN="${VIRTUAL_ENV}/bin"
+elif command -v poetry >/dev/null 2>&1; then
+    POETRY_VENV="$(cd "${PROJECT_ROOT}" && poetry env info -p 2>/dev/null || true)"
+    if [ -n "${POETRY_VENV}" ] && [ -f "${POETRY_VENV}/bin/alembic" ]; then
+        VENV_BIN="${POETRY_VENV}/bin"
+    fi
+fi
+
+if [ -n "${VENV_BIN}" ]; then
+    ALEMBIC="${VENV_BIN}/alembic"
+    PYTHON="${VENV_BIN}/python"
 else
     ALEMBIC="alembic"
     PYTHON="python"

--- a/api/migrate.sh
+++ b/api/migrate.sh
@@ -1,7 +1,12 @@
 #! /bin/bash
 
-ALEMBIC="alembic"
-PYTHON="python"
+if [ -f "/.venv/bin/alembic" ]; then
+    ALEMBIC="/.venv/bin/alembic"
+    PYTHON="/.venv/bin/python"
+else
+    ALEMBIC="alembic"
+    PYTHON="python"
+fi
 
 ALEMBIC_ARGS="-c db_migrations/alembic.ini"
 

--- a/api/migrate.sh
+++ b/api/migrate.sh
@@ -1,8 +1,7 @@
 #! /bin/bash
 
-POETRY=$(which poetry)
-ALEMBIC="${POETRY} run alembic"
-PYTHON="${POETRY} run python"
+ALEMBIC="alembic"
+PYTHON="python"
 
 ALEMBIC_ARGS="-c db_migrations/alembic.ini"
 

--- a/deploy/docker-local/Dockerfile
+++ b/deploy/docker-local/Dockerfile
@@ -13,5 +13,4 @@ WORKDIR /brewhouse-manager/api
 
 ENTRYPOINT []
 
-CMD poetry run ./migrate.sh upgrade head && \
-    poetry run python3 seed-db.py
+CMD . /.venv/bin/activate && ./migrate.sh upgrade head && python3 seed-db.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,5 +4,6 @@ if [ "$RUN_ENV" = "dev" ]; then
     export FLASK_ENV="development"
 fi
 
-poetry run ./migrate.sh upgrade head
-poetry run python app.py
+. /.venv/bin/activate
+./migrate.sh upgrade head
+python app.py


### PR DESCRIPTION
## Summary

- Refactors the Dockerfile into a clean 4-stage build: `node-base`, `python-build`, `node-build`, and `final` (starts from a clean `python:3.12-slim-trixie`). Poetry and all build tooling stay in `python-build` only; the final image copies in the pre-built `.venv` directory via `COPY --from=python-build`.
- Eliminates the perl CVE workaround (`--allow-remove-essential` purge) — it's no longer needed because the final stage starts from a clean base that never had perl installed.
- Updates `entrypoint.sh`, `api/migrate.sh`, and `deploy/docker-local/Dockerfile` to activate the venv directly (`. /.venv/bin/activate`) instead of using `poetry run`.
- Adds Docker Scout provenance and SBOM attestations to the `publish` Makefile target.
- Updates AGENTS.md architecture docs to reflect the new build layout.

## Test plan

- [ ] `docker build` completes successfully
- [ ] Container starts and runs migrations via `entrypoint.sh`
- [ ] Local dev seed container (`deploy/docker-local/`) runs migrations and seeds DB
- [ ] `make publish` includes attestation flags without errors
- [ ] Docker Scout scan shows no perl CVEs in the final image

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes container startup and migration paths—if venv resolution or bundled wheels fail on the slim base, deploys break; otherwise scope is build/packaging with documented runtime library assumptions.
> 
> **Overview**
> Refactors the production Docker build so **Poetry and compile-time tooling never land in the shipped image**. The `final` stage now starts from a clean `python:3.12-slim-trixie`, copies only the pre-built `/.venv` from `python-build`, and drops the old perl CVE purge on the runtime layer (perl never enters `final`).
> 
> **Runtime entrypoints** no longer call `poetry run`: `entrypoint.sh` and the local seed image activate `/.venv` before migrations and app startup; `api/migrate.sh` picks `/.venv`, project `.venv`, `VIRTUAL_ENV`, or Poetry’s env for local dev, then falls back to bare `alembic`/`python`.
> 
> `make publish` now passes **Docker provenance and SBOM attestations** alongside `--push`. **AGENTS.md** documents the four-stage layout, venv-only runtime rules, and when runtime `.so` dependencies might need an `apt-get` in `final`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1199fba92e8e619b76fad1e928f8fc1a9fdecb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->